### PR TITLE
Fix up links to point to correct repo locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Please see __[Compatibility Testing](test/)__.
 
 --
 
-_Source code for the animated figures above: [mobile-viewport-control-viz](https://github.com/shaunstripe/mobile-viewport-control-viz)_
+_Source code for the animated figures above: [mobile-viewport-control-viz](https://github.com/shaun-stripe/mobile-viewport-control-viz)_
 
 
 [scroll-gif]:https://zippy.gfycat.com/EnchantedPowerfulIndri.gif

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 // Copyright (c) 2016 Shaun Williams
 // ISC License
 //
-// GitHub: https://github.com/shaunstripe/mobile-viewport-control
+// GitHub: https://github.com/stripe/mobile-viewport-control
 //
 
 //---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/shaunstripe/mobile-viewport-control.git"
+    "url": "git+https://github.com/stripe/mobile-viewport-control.git"
   },
   "files": [
     "index.js"

--- a/test/README.md
+++ b/test/README.md
@@ -48,9 +48,9 @@ page's scale to change from its specified `initial-scale`.  This custom zoom
 level is maintained across refreshes.  When opening in a new tab, the
 `initial-scale` is resumed._
 
-[Measure Test]:http://shaunstripe.github.io/mobile-viewport-control/test/unit/01-measure.html
-[Freeze Test]:http://shaunstripe.github.io/mobile-viewport-control/test/unit/02-freeze.html
-[Thaw Test]:http://shaunstripe.github.io/mobile-viewport-control/test/unit/03-thaw.html
+[Measure Test]:http://stripe.github.io/mobile-viewport-control/test/unit/01-measure.html
+[Freeze Test]:http://stripe.github.io/mobile-viewport-control/test/unit/02-freeze.html
+[Thaw Test]:http://stripe.github.io/mobile-viewport-control/test/unit/03-thaw.html
 [Injection Method]:#injecting-into-existing-pages
 
 ## Injecting into Existing Pages
@@ -70,7 +70,7 @@ The following bookmarklet will freeze the viewport scale, show a custom
 isolated element, and allow you to press a button to restore the view.
 
 ```js
-javascript:(function(){document.body.appendChild(document.createElement('script')).src='https://rawgit.com/shaunstripe/mobile-viewport-control/master/test/bookmarklet/index.js?'+Math.random();}())
+javascript:(function(){document.body.appendChild(document.createElement('script')).src='https://stripe.github.io/mobile-viewport-control/test/bookmarklet/index.js?'+Math.random();}())
 ```
 
 ### With DevTools
@@ -82,7 +82,7 @@ Chrome/webview can connect to Desktop Chrome DevTools.  Inside DevTools, we can
 simply paste the body of the bookmarklet inside the JS console:
 
 ```js
-document.body.appendChild(document.createElement('script')).src='https://rawgit.com/shaunstripe/mobile-viewport-control/master/test/bookmarklet/index.js?'+Math.random();
+document.body.appendChild(document.createElement('script')).src='https://stripe.github.io/mobile-viewport-control/test/bookmarklet/index.js?'+Math.random();
 ```
 
 iOS webviews require an extra step: you must run an webview app from a live


### PR DESCRIPTION
It appears that the author of this code had originally located the repo under their `shaunstripe` username. It's been moved into the Stripe org, but the links haven't been modified. In addition to this, the user has been renamed to `shaun-stripe`.

The links have now been fixed up where possible to point to the new repo location under the Stripe org. There's one link that still points to a repo outside of the org, but this has been re-pointed to the correct username.